### PR TITLE
added query params as props for Todo #3

### DIFF
--- a/ReactMapboxAutocomplete.js
+++ b/ReactMapboxAutocomplete.js
@@ -11,6 +11,10 @@ const ReactMapboxAutocomplete = React.createClass ({
     country: React.PropTypes.string,
     query: React.PropTypes.string,
     limit: React.PropTypes.number,
+    proximity: React.PropTypes.string,
+    types: React.PropTypes.string,
+    bbox: React.PropTypes.string,
+    autocomplete: React.PropTypes.bool,
     resetSearch: React.PropTypes.bool
   },
 
@@ -38,8 +42,13 @@ const ReactMapboxAutocomplete = React.createClass ({
 
     let countryOpt = this.props.country ? `&country=${this.props.country}` : '';
     let limitOpt = this.props.limit ? `&limit=${this.props.limit}` : '';
+    let proximityOpt = this.props.proximity ? `&proximity=${this.props.proximity}` : '';
+    let typesOpt = this.props.types ? `&types=${this.props.types}` : '';
+    let bboxOpt = this.props.bbox ? `&bbox=${this.props.bbox}` : '';
+    let autocompleteOpt = this.props.autocomplete == false ? `&autocomplete=${this.props.autocomplete}` : '';
 
-    let path = (host + query + token) + countryOpt + limitOpt;
+    let path = 
+    (host + query + token) + countryOpt + limitOpt + proximityOpt + typesOpt + bboxOpt + autocompleteOpt;
 
     if(this.state.query.length > 2) {
       return fetch(path, {

--- a/ReactMapboxAutocomplete.js
+++ b/ReactMapboxAutocomplete.js
@@ -10,6 +10,7 @@ const ReactMapboxAutocomplete = React.createClass ({
     onSuggestionSelect: React.PropTypes.func.isRequired,
     country: React.PropTypes.string,
     query: React.PropTypes.string,
+    limit: React.PropTypes.number,
     resetSearch: React.PropTypes.bool
   },
 
@@ -31,19 +32,14 @@ const ReactMapboxAutocomplete = React.createClass ({
       'Content-Type': 'application/json'
     }
 
-    if(this.props.country) {
-      var path = 'https://api.mapbox.com/geocoding/v5/mapbox.places/' +
-                  this.state.query +
-                  '.json?access_token=' +
-                  this.state.publicKey +
-                  '&country=' +
-                  this.props.country
-    } else {
-      path = 'https://api.mapbox.com/geocoding/v5/mapbox.places/' +
-              this.state.query +
-              '.json?access_token=' +
-              this.state.publicKey
-    }
+    let host = 'https://api.mapbox.com/geocoding/v5/mapbox.places/';
+    let query = `${this.state.query}.json?`;
+    let token = `access_token=${this.state.publicKey}`;
+
+    let countryOpt = this.props.country ? `&country=${this.props.country}` : '';
+    let limitOpt = this.props.limit ? `&limit=${this.props.limit}` : '';
+
+    let path = (host + query + token) + countryOpt + limitOpt;
 
     if(this.state.query.length > 2) {
       return fetch(path, {


### PR DESCRIPTION
hello!

I added the optional queryparams as props from mapbox api and refactored a bit of the url concatenation.  

per the mapbox api docs:

> limit - Limit the number of results returned. The default is  5 for forward geocoding and  1 for reverse geocoding.
proximity - Location around which to bias results, given as  longitude,latitude
types - Filter results by one or more type. Options are  country ,  region ,  postcode ,  place ,  locality ,  neighborhood , address ,  poi ,  poi.landmark . Multiple options can be comma-separated.
autocomplete - Whether or not to return autocomplete results. Options are  true and  false . The default is  true .
bbox - Bounding box within which to limit results, given as  minX,minY,maxX,maxY

https://www.mapbox.com/api-documentation/#geocoding