### PR TITLE
Tackling Todo #3

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,13 +116,15 @@ You can style the following classes as you see fit.
 ```
 
 ## ToDo
-1. Tests
- - Implement JEST
- - Test: each function and render
+1. ~~Tests~~
+ - ~~Implement JEST~~
+ - ~~Test: each function and render~~
+
 2. Add Examples
  - add examples to project in a folder called "Examples"
-3. Add all query params as Props
- - implement the remainder of query params from https://www.mapbox.com/api-documentation/#request-format
+
+3. ~~Add all query params as Props~~
+ - ~~implement the remainder of query params from https://www.mapbox.com/api-documentation/#request-format~~
 
 ## Contributing
 If you would like to contribute to react-mapbox-autocomplete fork the project

--- a/README.md
+++ b/README.md
@@ -37,18 +37,26 @@ with any version of ES.
 
 ### Available PropTypes
 
-publicKey:**Required(String)**
+publicKey: **Required (String)**
 
-inputClass:**Optional(String)**:Used for passing bootstrap or other classes for input styling
+inputClass: **Optional (String)**: Used for passing bootstrap or other classes for input styling
 
-country:**Optional(String)**
+onSuggestionSelect: **Required (Func)**: For handling suggestion selections
 
-onSuggestionSelect:**Required(Func)**:For handling suggestion selections
+query: **Optional (String)**: Pre-populate search field
 
-query:**Optional(String)**:Pre-populate search field
-
-resetSearch:**Optional(Boolean)**: Default is false. Resets the input field
+resetSearch: **Optional (Boolean)**: Default is false. Resets the input field
 after suggestion select
+
+country: **Optional (String)**: Separated by commas
+
+proximity: **Optional (Array)**: [longitude, latitude]
+
+filterTypes: **Optional (String)**: Filter results by one or more type. Options are country, region, postcode, place,  locality, neighborhood, address, poi, poi.landmark  . Multiple options can be comma-separated.
+
+bbox: **Optional (Array)**: Bounding box within which to limit results, given as [minX, minY, maxX, maxY]
+
+limit: **Optional (Numeric)**: Limits the number of results returned.  Default is 5.
 
 ### Retriving Suggestion Information
 you can retrive the event data by targeting event.target.dataset.suggestion as
@@ -70,8 +78,9 @@ _suggestionSelect(result, lat, lng, text) {
 <MapboxAutocomplete publicKey='Your Mapbox Public Key'
                     inputClass='form-control search'
                     onSuggestionSelect={this._suggestionSelect}
-                    country='us'
-                    resetSearch={false}/>
+                    resetSearch={false}
+                    country='us'/>
+
 ```
 
 ## Styling
@@ -107,7 +116,7 @@ You can style the following classes as you see fit.
 ```
 
 ## ToDo
-1. Tests 
+1. Tests
  - Implement JEST
  - Test: each function and render
 2. Add Examples

--- a/ReactMapboxAutocomplete.js
+++ b/ReactMapboxAutocomplete.js
@@ -81,6 +81,7 @@ export default class ReactMapboxAutocomplete extends Component {
   _resetSearch() {
 
     this.setState({
+      error: false,
       query: (this.props.resetSearch) ? event.target.getAttribute('data-suggestion') : '',
       queryResults: []
     });

--- a/ReactMapboxAutocomplete.js
+++ b/ReactMapboxAutocomplete.js
@@ -1,94 +1,109 @@
-import React from 'react';
+import React, { Component } from 'react';
 import './index.css';
 import { map, extend } from 'lodash';
 
-const ReactMapboxAutocomplete = React.createClass ({
-  propTypes: {
-    inputClass: React.PropTypes.string,
-    publicKey: React.PropTypes.string.isRequired,
-    placeholder: React.PropTypes.string,
-    onSuggestionSelect: React.PropTypes.func.isRequired,
-    country: React.PropTypes.string,
-    query: React.PropTypes.string,
-    resetSearch: React.PropTypes.bool
-  },
+export default class ReactMapboxAutocomplete extends Component {
 
-  getInitialState() {
-    let state = {
-      query: this.props.query ? this.props.query : '',
+  constructor(props) {
+    super(props);
+    // initial state
+    this.state = {
+      query: props.query || '',
       queryResults: [],
-      publicKey: this.props.publicKey,
-      resetSearch: this.props.resetSearch ? this.props.resetSearch : false
-    }
-
-    return state;
-  },
+    };
+    // bind this
+    this._updateQuery = this._updateQuery.bind(this);
+    this._onSuggestionSelect = this._onSuggestionSelect.bind(this);
+  }
 
   _updateQuery(event) {
-    this.setState(_.extend(this.state, {query: event.target.value}))
+    // update query
+    this.setState(_.extend(this.state, {query: event.target.value}));
 
-    let header = {
-      'Content-Type': 'application/json'
-    }
-
-    if(this.props.country) {
-      var path = 'https://api.mapbox.com/geocoding/v5/mapbox.places/' +
-                  this.state.query +
-                  '.json?access_token=' +
-                  this.state.publicKey +
-                  '&country=' +
-                  this.props.country
-    } else {
-      path = 'https://api.mapbox.com/geocoding/v5/mapbox.places/' +
-              this.state.query +
-              '.json?access_token=' +
-              this.state.publicKey
-    }
-
-    if(this.state.query.length > 2) {
-      return fetch(path, {
-        headers: header,
-      }).then((res) => {
-        return res.json()
-      }).then((json) => {
-        this.setState(_.extend(this.state, {
-          queryResults: json.features
-        }))
-      })
-    } else {
-      this.setState(_.extend(this.state, {
+    // only continue for queries 3 chars or longer
+    if (this.state.query.length <= 2) {
+      return this.setState(_.extend(this.state, {
         queryResults: []
-      }))
+      }));
     }
-  },
+
+    // helper
+    const validateNumericArray = function(array, len) {
+      return (array && array.length === len) && array.every(function isNumber(n) {
+        return !isNaN(parseFloat(n)) && isFinite(n);
+      });
+    };
+
+    // preparing API request
+    const apiEndpoint = 'https://api.mapbox.com/geocoding/v5/mapbox.places/' + this.state.query + '.json';
+    const qsParams = {
+      access_token: this.props.publicKey,
+      country: this.props.country,
+      limit: this.props.limit,
+      types: this.props.filterTypes,
+      proximity: validateNumericArray(this.props.proximity, 2) ? this.props.proximity.join(',') : null,
+      bbox: validateNumericArray(this.props.bbox, 4) ? this.props.proximity.join(',') : null
+    };
+    const path = apiEndpoint + '?' + (function objectToQuerystring(obj) {
+      return Object.keys(obj).filter((key) => {
+        return !!obj[key];
+      }).map((key) => {
+        return key + '=' + obj[key];
+      }).join('&');
+    })(qsParams);
+
+    const headers = {
+      'Content-Type': 'application/json'
+    };
+
+    // fetch mapbox API then update queryResults state
+    return fetch(path, {
+      headers: headers,
+    }).then((res) => {
+      return res.json();
+    }).then((json) => {
+      this.setState(_.extend(this.state, {
+        queryResults: json.features
+      }));
+    });
+
+  }
 
   _resetSearch() {
-    if(this.state.resetSearch) {
-      this.setState({
-        query: '',
-        queryResults: []
-      })
-    } else {
-      this.setState(_.extend(this.state, {
-        queryResults: []
-      }))
+
+    let newState = {
+      queryResults: []
+    };
+
+    if (this.props.resetSearch) {
+      newState.query = '';
     }
-  },
+
+    this.setState(newState);
+
+  }
 
   _onSuggestionSelect(event) {
-    if(this.state.resetSearch === false) {
-      this.setState(_.extend(this.state, {
-        query: event.target.dataset.suggestion
-      }))
-    }
+
+    const newState = (this.props.resetSearch) ? {
+      query: '',
+      queryResults: []
+    } : {
+      query: event.target.dataset.suggestion
+    };
+
+    this.setState(_.extend(this.state, newState));
 
     this.props.onSuggestionSelect(
       event.target.dataset.suggestion,
       event.target.dataset.lat,
       event.target.dataset.lng,
       event.target.dataset.text
-    )
-  },
+    );
+
+    this._resetSearch();
+
+  }
 
   render() {
     return (
@@ -103,8 +118,7 @@ const ReactMapboxAutocomplete = React.createClass ({
         <span>
           <div className='react-mapbox-ac-menu'
                style={this.state.queryResults.length > 0 ? { display: 'block' }
-               : { display: 'none' }}
-               onClick={this._resetSearch}>
+               : { display: 'none' }}>
 
             {
               _.map(this.state.queryResults, (place, i) => {
@@ -128,6 +142,18 @@ const ReactMapboxAutocomplete = React.createClass ({
       </div>
     );
   }
-})
+}
 
-export default ReactMapboxAutocomplete;
+ReactMapboxAutocomplete.propTypes = {
+  inputClass: React.PropTypes.string,
+  publicKey: React.PropTypes.string.isRequired,
+  placeholder: React.PropTypes.string,
+  onSuggestionSelect: React.PropTypes.func.isRequired,
+  country: React.PropTypes.string,
+  query: React.PropTypes.string,
+  resetSearch: React.PropTypes.bool,
+  limit: React.PropTypes.number,
+  types: React.PropTypes.string,
+  proximity: React.PropTypes.array,
+  bbox: React.PropTypes.array
+};

--- a/ReactMapboxAutocomplete.js
+++ b/ReactMapboxAutocomplete.js
@@ -22,7 +22,7 @@ export default class ReactMapboxAutocomplete extends Component {
 
     // only continue for queries 3 chars or longer
     if (this.state.query.length <= 2) {
-      return this.setState(_.extend(this.state, {
+      return this.setState(extend(this.state, {
         error: false,
         queryResults: []
       }));
@@ -60,11 +60,11 @@ export default class ReactMapboxAutocomplete extends Component {
     // fetch mapbox API then update queryResults state
     return fetch(path, {
       headers: headers,
-    }).then((res) => {
+    }).then(res => {
       if (!res.ok) throw Error(res.statusText);
       return res.json();
-    }).then((json) => {
-      this.setState(_.extend(this.state, {
+    }).then(json => {
+      this.setState(extend(this.state, {
         error: false,
         queryResults: json.features
       }));

--- a/__tests__/__snapshots__/ReactMapboxAutocomplete.spec.js.snap
+++ b/__tests__/__snapshots__/ReactMapboxAutocomplete.spec.js.snap
@@ -13,7 +13,6 @@ exports[`render should render component in an error state 1`] = `
     <span>
       <div
         className="react-mapbox-ac-menu"
-        onClick={[Function]}
         style={
           Object {
             "display": "block",
@@ -44,7 +43,6 @@ exports[`render should render component with query results 1`] = `
     <span>
       <div
         className="react-mapbox-ac-menu"
-        onClick={[Function]}
         style={
           Object {
             "display": "block",

--- a/index.js
+++ b/index.js
@@ -4,6 +4,8 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
 var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
@@ -14,117 +16,172 @@ var _lodash = require('lodash');
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-var ReactMapboxAutocomplete = _react2.default.createClass({
-  displayName: 'ReactMapboxAutocomplete',
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
-  propTypes: {
-    inputClass: _react2.default.PropTypes.string,
-    publicKey: _react2.default.PropTypes.string.isRequired,
-    placeholder: _react2.default.PropTypes.string,
-    onSuggestionSelect: _react2.default.PropTypes.func.isRequired,
-    country: _react2.default.PropTypes.string,
-    query: _react2.default.PropTypes.string,
-    resetSearch: _react2.default.PropTypes.bool
-  },
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
 
-  getInitialState: function getInitialState() {
-    var state = {
-      query: this.props.query ? this.props.query : '',
-      queryResults: [],
-      publicKey: this.props.publicKey,
-      resetSearch: this.props.resetSearch ? this.props.resetSearch : false
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+var ReactMapboxAutocomplete = function (_Component) {
+  _inherits(ReactMapboxAutocomplete, _Component);
+
+  function ReactMapboxAutocomplete(props) {
+    _classCallCheck(this, ReactMapboxAutocomplete);
+
+    // initial state
+    var _this = _possibleConstructorReturn(this, (ReactMapboxAutocomplete.__proto__ || Object.getPrototypeOf(ReactMapboxAutocomplete)).call(this, props));
+
+    _this.state = {
+      query: props.query || '',
+      queryResults: []
     };
+    // bind this
+    _this._updateQuery = _this._updateQuery.bind(_this);
+    _this._onSuggestionSelect = _this._onSuggestionSelect.bind(_this);
+    return _this;
+  }
 
-    return state;
-  },
-  _updateQuery: function _updateQuery(event) {
-    var _this = this;
+  _createClass(ReactMapboxAutocomplete, [{
+    key: '_updateQuery',
+    value: function _updateQuery(event) {
+      var _this2 = this;
 
-    this.setState(_.extend(this.state, { query: event.target.value }));
+      // update query
+      this.setState(_.extend(this.state, { query: event.target.value }));
 
-    var header = {
-      'Content-Type': 'application/json'
-    };
+      // only continue for queries 3 chars or longer
+      if (this.state.query.length <= 2) {
+        return this.setState(_.extend(this.state, {
+          queryResults: []
+        }));
+      }
 
-    if (this.props.country) {
-      var path = 'https://api.mapbox.com/geocoding/v5/mapbox.places/' + this.state.query + '.json?access_token=' + this.state.publicKey + '&country=' + this.props.country;
-    } else {
-      path = 'https://api.mapbox.com/geocoding/v5/mapbox.places/' + this.state.query + '.json?access_token=' + this.state.publicKey;
-    }
+      // helper
+      var validateNumericArray = function validateNumericArray(array, len) {
+        return array && array.length === len && array.every(function isNumber(n) {
+          return !isNaN(parseFloat(n)) && isFinite(n);
+        });
+      };
 
-    if (this.state.query.length > 2) {
+      // preparing API request
+      var apiEndpoint = 'https://api.mapbox.com/geocoding/v5/mapbox.places/' + this.state.query + '.json';
+      var qsParams = {
+        access_token: this.props.publicKey,
+        country: this.props.country,
+        limit: this.props.limit,
+        types: this.props.filterTypes,
+        proximity: validateNumericArray(this.props.proximity, 2) ? this.props.proximity.join(',') : null,
+        bbox: validateNumericArray(this.props.bbox, 4) ? this.props.proximity.join(',') : null
+      };
+      var path = apiEndpoint + '?' + function objectToQuerystring(obj) {
+        return Object.keys(obj).filter(function (key) {
+          return !!obj[key];
+        }).map(function (key) {
+          return key + '=' + obj[key];
+        }).join('&');
+      }(qsParams);
+
+      var headers = {
+        'Content-Type': 'application/json'
+      };
+
+      // fetch mapbox API then update queryResults state
       return fetch(path, {
-        headers: header
+        headers: headers
       }).then(function (res) {
         return res.json();
       }).then(function (json) {
-        _this.setState(_.extend(_this.state, {
+        _this2.setState(_.extend(_this2.state, {
           queryResults: json.features
         }));
       });
-    } else {
-      this.setState(_.extend(this.state, {
-        queryResults: []
-      }));
     }
-  },
-  _resetSearch: function _resetSearch() {
-    if (this.state.resetSearch) {
-      this.setState({
+  }, {
+    key: '_resetSearch',
+    value: function _resetSearch() {
+
+      var newState = {
+        queryResults: []
+      };
+
+      if (this.props.resetSearch) {
+        newState.query = '';
+      }
+
+      this.setState(newState);
+    }
+  }, {
+    key: '_onSuggestionSelect',
+    value: function _onSuggestionSelect(event) {
+
+      var newState = this.props.resetSearch ? {
         query: '',
         queryResults: []
-      });
-    } else {
-      this.setState(_.extend(this.state, {
-        queryResults: []
-      }));
-    }
-  },
-  _onSuggestionSelect: function _onSuggestionSelect(event) {
-    if (this.state.resetSearch === false) {
-      this.setState(_.extend(this.state, {
+      } : {
         query: event.target.dataset.suggestion
-      }));
+      };
+
+      this.setState(_.extend(this.state, newState));
+
+      this.props.onSuggestionSelect(event.target.dataset.suggestion, event.target.dataset.lat, event.target.dataset.lng, event.target.dataset.text);
+
+      this._resetSearch();
     }
+  }, {
+    key: 'render',
+    value: function render() {
+      var _this3 = this;
 
-    this.props.onSuggestionSelect(event.target.dataset.suggestion, event.target.dataset.lat, event.target.dataset.lng, event.target.dataset.text);
-  },
-  render: function render() {
-    var _this2 = this;
-
-    return _react2.default.createElement(
-      'div',
-      null,
-      _react2.default.createElement('input', { placeholder: this.props.placeholder || 'Search',
-        className: this.props.inputClass ? this.props.inputClass + ' react-mapbox-ac-input' : 'react-mapbox-ac-input',
-        onChange: this._updateQuery,
-        value: this.state.query,
-        type: 'text' }),
-      _react2.default.createElement(
-        'span',
+      return _react2.default.createElement(
+        'div',
         null,
+        _react2.default.createElement('input', { placeholder: this.props.placeholder || 'Search',
+          className: this.props.inputClass ? this.props.inputClass + ' react-mapbox-ac-input' : 'react-mapbox-ac-input',
+          onChange: this._updateQuery,
+          value: this.state.query,
+          type: 'text' }),
         _react2.default.createElement(
-          'div',
-          { className: 'react-mapbox-ac-menu',
-            style: this.state.queryResults.length > 0 ? { display: 'block' } : { display: 'none' },
-            onClick: this._resetSearch },
-          _.map(this.state.queryResults, function (place, i) {
-            return _react2.default.createElement(
-              'div',
-              { className: 'react-mapbox-ac-suggestion',
-                onClick: _this2._onSuggestionSelect,
-                key: i,
-                'data-suggestion': place.place_name,
-                'data-lng': place.center[0],
-                'data-lat': place.center[1],
-                'data-text': place.text },
-              place.place_name
-            );
-          })
+          'span',
+          null,
+          _react2.default.createElement(
+            'div',
+            { className: 'react-mapbox-ac-menu',
+              style: this.state.queryResults.length > 0 ? { display: 'block' } : { display: 'none' } },
+            _.map(this.state.queryResults, function (place, i) {
+              return _react2.default.createElement(
+                'div',
+                { className: 'react-mapbox-ac-suggestion',
+                  onClick: _this3._onSuggestionSelect,
+                  key: i,
+                  'data-suggestion': place.place_name,
+                  'data-lng': place.center[0],
+                  'data-lat': place.center[1],
+                  'data-text': place.text },
+                place.place_name
+              );
+            })
+          )
         )
-      )
-    );
-  }
-});
+      );
+    }
+  }]);
+
+  return ReactMapboxAutocomplete;
+}(_react.Component);
 
 exports.default = ReactMapboxAutocomplete;
+
+
+ReactMapboxAutocomplete.propTypes = {
+  inputClass: _react2.default.PropTypes.string,
+  publicKey: _react2.default.PropTypes.string.isRequired,
+  placeholder: _react2.default.PropTypes.string,
+  onSuggestionSelect: _react2.default.PropTypes.func.isRequired,
+  country: _react2.default.PropTypes.string,
+  query: _react2.default.PropTypes.string,
+  resetSearch: _react2.default.PropTypes.bool,
+  limit: _react2.default.PropTypes.number,
+  types: _react2.default.PropTypes.string,
+  proximity: _react2.default.PropTypes.array,
+  bbox: _react2.default.PropTypes.array
+};

--- a/index.js
+++ b/index.js
@@ -16,46 +16,17 @@ var _lodash = require('lodash');
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-<<<<<<< HEAD
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
 function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
 
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
-=======
-var ReactMapboxAutocomplete = _react2.default.createClass({
-  displayName: 'ReactMapboxAutocomplete',
-
-  propTypes: {
-    inputClass: _react2.default.PropTypes.string,
-    publicKey: _react2.default.PropTypes.string.isRequired,
-    placeholder: _react2.default.PropTypes.string,
-    onSuggestionSelect: _react2.default.PropTypes.func.isRequired,
-    country: _react2.default.PropTypes.string,
-    query: _react2.default.PropTypes.string,
-    resetSearch: _react2.default.PropTypes.bool
-  },
-
-  getInitialState: function getInitialState() {
-    var state = {
-      error: false,
-      errorMsg: '',
-      query: this.props.query ? this.props.query : '',
-      queryResults: [],
-      publicKey: this.props.publicKey,
-      resetSearch: this.props.resetSearch ? this.props.resetSearch : false
-    };
->>>>>>> c7fafd86364ae16b012a2f4512c00f21a1deb807
 
 var ReactMapboxAutocomplete = function (_Component) {
   _inherits(ReactMapboxAutocomplete, _Component);
 
-<<<<<<< HEAD
   function ReactMapboxAutocomplete(props) {
     _classCallCheck(this, ReactMapboxAutocomplete);
-=======
-    this.setState((0, _lodash.extend)(this.state, { query: event.target.value }));
->>>>>>> c7fafd86364ae16b012a2f4512c00f21a1deb807
 
     // initial state
     var _this = _possibleConstructorReturn(this, (ReactMapboxAutocomplete.__proto__ || Object.getPrototypeOf(ReactMapboxAutocomplete)).call(this, props));
@@ -75,12 +46,12 @@ var ReactMapboxAutocomplete = function (_Component) {
     value: function _updateQuery(event) {
       var _this2 = this;
 
-      // update query
-      this.setState(_.extend(this.state, { query: event.target.value }));
+      this.setState((0, _lodash.extend)(this.state, { query: event.target.value }));
 
       // only continue for queries 3 chars or longer
       if (this.state.query.length <= 2) {
         return this.setState(_.extend(this.state, {
+          error: false,
           queryResults: []
         }));
       }
@@ -121,99 +92,42 @@ var ReactMapboxAutocomplete = function (_Component) {
         if (!res.ok) throw Error(res.statusText);
         return res.json();
       }).then(function (json) {
-<<<<<<< HEAD
         _this2.setState(_.extend(_this2.state, {
-=======
-        _this.setState((0, _lodash.extend)(_this.state, {
           error: false,
->>>>>>> c7fafd86364ae16b012a2f4512c00f21a1deb807
           queryResults: json.features
         }));
       }).catch(function (err) {
-        _this.setState((0, _lodash.extend)(_this.state, {
+        _this2.setState((0, _lodash.extend)(_this2.state, {
           error: true,
           errorMsg: 'There was a problem retrieving data from mapbox',
           queryResults: []
         }));
       });
-<<<<<<< HEAD
     }
   }, {
     key: '_resetSearch',
     value: function _resetSearch() {
 
-      var newState = {
-=======
-    } else {
-      this.setState((0, _lodash.extend)(this.state, {
-        error: false,
->>>>>>> c7fafd86364ae16b012a2f4512c00f21a1deb807
+      this.setState({
+        query: this.props.resetSearch ? event.target.getAttribute('data-suggestion') : '',
         queryResults: []
-      };
-
-      if (this.props.resetSearch) {
-        newState.query = '';
-      }
-
-      this.setState(newState);
+      });
     }
   }, {
     key: '_onSuggestionSelect',
     value: function _onSuggestionSelect(event) {
 
-      var newState = this.props.resetSearch ? {
-        query: '',
-        queryResults: []
-<<<<<<< HEAD
-      } : {
-        query: event.target.dataset.suggestion
-      };
-
-      this.setState(_.extend(this.state, newState));
-
-      this.props.onSuggestionSelect(event.target.dataset.suggestion, event.target.dataset.lat, event.target.dataset.lng, event.target.dataset.text);
+      this.props.onSuggestionSelect(event.target.getAttribute('data-suggestion'), event.target.getAttribute('data-lat'), event.target.getAttribute('data-lng'), event.target.getAttribute('data-text'));
 
       this._resetSearch();
-=======
-      });
-    } else {
-      this.setState((0, _lodash.extend)(this.state, {
-        queryResults: []
-      }));
-    }
-  },
-  _onSuggestionSelect: function _onSuggestionSelect(event) {
-    if (this.state.resetSearch === false) {
-      this.setState((0, _lodash.extend)(this.state, {
-        query: event.target.getAttribute('data-suggestion')
-      }));
->>>>>>> c7fafd86364ae16b012a2f4512c00f21a1deb807
     }
   }, {
     key: 'render',
     value: function render() {
       var _this3 = this;
 
-<<<<<<< HEAD
       return _react2.default.createElement(
         'div',
-=======
-    this.props.onSuggestionSelect(event.target.getAttribute('data-suggestion'), event.target.getAttribute('data-lat'), event.target.getAttribute('data-lng'), event.target.getAttribute('data-text'));
-  },
-  render: function render() {
-    var _this2 = this;
-
-    return _react2.default.createElement(
-      'div',
-      null,
-      _react2.default.createElement('input', { placeholder: this.props.placeholder || 'Search',
-        className: this.props.inputClass ? this.props.inputClass + ' react-mapbox-ac-input' : 'react-mapbox-ac-input',
-        onChange: this._updateQuery,
-        value: this.state.query,
-        type: 'text' }),
-      _react2.default.createElement(
-        'span',
->>>>>>> c7fafd86364ae16b012a2f4512c00f21a1deb807
         null,
         _react2.default.createElement('input', { placeholder: this.props.placeholder || 'Search',
           className: this.props.inputClass ? this.props.inputClass + ' react-mapbox-ac-input' : 'react-mapbox-ac-input',
@@ -221,14 +135,13 @@ var ReactMapboxAutocomplete = function (_Component) {
           value: this.state.query,
           type: 'text' }),
         _react2.default.createElement(
-<<<<<<< HEAD
           'span',
           null,
           _react2.default.createElement(
             'div',
             { className: 'react-mapbox-ac-menu',
-              style: this.state.queryResults.length > 0 ? { display: 'block' } : { display: 'none' } },
-            _.map(this.state.queryResults, function (place, i) {
+              style: this.state.queryResults.length > 0 || this.state.error ? { display: 'block' } : { display: 'none' } },
+            (0, _lodash.map)(this.state.queryResults, function (place, i) {
               return _react2.default.createElement(
                 'div',
                 { className: 'react-mapbox-ac-suggestion',
@@ -240,30 +153,12 @@ var ReactMapboxAutocomplete = function (_Component) {
                   'data-text': place.text },
                 place.place_name
               );
-            })
-=======
-          'div',
-          { className: 'react-mapbox-ac-menu',
-            style: this.state.queryResults.length > 0 || this.state.error ? { display: 'block' } : { display: 'none' },
-            onClick: this._resetSearch },
-          (0, _lodash.map)(this.state.queryResults, function (place, i) {
-            return _react2.default.createElement(
+            }),
+            this.state.error && _react2.default.createElement(
               'div',
-              { className: 'react-mapbox-ac-suggestion',
-                onClick: _this2._onSuggestionSelect,
-                key: i,
-                'data-suggestion': place.place_name,
-                'data-lng': place.center[0],
-                'data-lat': place.center[1],
-                'data-text': place.text },
-              place.place_name
-            );
-          }),
-          this.state.error && _react2.default.createElement(
-            'div',
-            { className: 'react-mapbox-ac-suggestion' },
-            this.state.errorMsg
->>>>>>> c7fafd86364ae16b012a2f4512c00f21a1deb807
+              { className: 'react-mapbox-ac-suggestion' },
+              this.state.errorMsg
+            )
           )
         )
       );


### PR DESCRIPTION
- React.createClass -> ES6 Class extending Component
- stripped down unnecessary state
- added support for proximity, filterTypes, bbox and limit Mapbox querystring filters as optional props