### PR TITLE
Jest and Enzyme tests

### DIFF
--- a/ReactMapboxAutocomplete.js
+++ b/ReactMapboxAutocomplete.js
@@ -25,7 +25,7 @@ const ReactMapboxAutocomplete = React.createClass ({
   },
 
   _updateQuery(event) {
-    this.setState(_.extend(this.state, {query: event.target.value}))
+    this.setState(extend(this.state, {query: event.target.value}))
 
     let header = {
       'Content-Type': 'application/json'
@@ -51,12 +51,12 @@ const ReactMapboxAutocomplete = React.createClass ({
       }).then((res) => {
         return res.json()
       }).then((json) => {
-        this.setState(_.extend(this.state, {
+        this.setState(extend(this.state, {
           queryResults: json.features
         }))
       })
     } else {
-      this.setState(_.extend(this.state, {
+      this.setState(extend(this.state, {
         queryResults: []
       }))
     }
@@ -69,7 +69,7 @@ const ReactMapboxAutocomplete = React.createClass ({
         queryResults: []
       })
     } else {
-      this.setState(_.extend(this.state, {
+      this.setState(extend(this.state, {
         queryResults: []
       }))
     }
@@ -77,16 +77,16 @@ const ReactMapboxAutocomplete = React.createClass ({
 
   _onSuggestionSelect(event) {
     if(this.state.resetSearch === false) {
-      this.setState(_.extend(this.state, {
-        query: event.target.dataset.suggestion
+      this.setState(extend(this.state, {
+        query: event.target.getAttribute('data-suggestion')
       }))
     }
 
     this.props.onSuggestionSelect(
-      event.target.dataset.suggestion,
-      event.target.dataset.lat,
-      event.target.dataset.lng,
-      event.target.dataset.text
+      event.target.getAttribute('data-suggestion'),
+      event.target.getAttribute('data-lat'),
+      event.target.getAttribute('data-lng'),
+      event.target.getAttribute('data-text')
     )
   },
 
@@ -107,7 +107,7 @@ const ReactMapboxAutocomplete = React.createClass ({
                onClick={this._resetSearch}>
 
             {
-              _.map(this.state.queryResults, (place, i) => {
+              map(this.state.queryResults, (place, i) => {
                 return(
                   <div className='react-mapbox-ac-suggestion'
                        onClick={this._onSuggestionSelect}

--- a/ReactMapboxAutocomplete.js
+++ b/ReactMapboxAutocomplete.js
@@ -15,6 +15,8 @@ const ReactMapboxAutocomplete = React.createClass ({
 
   getInitialState() {
     let state = {
+      error: false,
+      errorMsg: '',
       query: this.props.query ? this.props.query : '',
       queryResults: [],
       publicKey: this.props.publicKey,
@@ -48,15 +50,24 @@ const ReactMapboxAutocomplete = React.createClass ({
     if(this.state.query.length > 2) {
       return fetch(path, {
         headers: header,
-      }).then((res) => {
+      }).then(res => {
+        if (!res.ok) throw Error(res.statusText)
         return res.json()
-      }).then((json) => {
+      }).then(json => {
         this.setState(extend(this.state, {
+          error: false,
           queryResults: json.features
+        }))
+      }).catch(err => {
+        this.setState(extend(this.state, {
+          error: true,
+          errorMsg: 'There was a problem retrieving data from mapbox',
+          queryResults: []
         }))
       })
     } else {
       this.setState(extend(this.state, {
+        error: false,
         queryResults: []
       }))
     }
@@ -102,7 +113,7 @@ const ReactMapboxAutocomplete = React.createClass ({
                type='text'/>
         <span>
           <div className='react-mapbox-ac-menu'
-               style={this.state.queryResults.length > 0 ? { display: 'block' }
+               style={this.state.queryResults.length > 0 || this.state.error ? { display: 'block' }
                : { display: 'none' }}
                onClick={this._resetSearch}>
 
@@ -123,6 +134,8 @@ const ReactMapboxAutocomplete = React.createClass ({
                 )
               })
             }
+
+            {this.state.error && <div className="react-mapbox-ac-suggestion">{this.state.errorMsg}</div>}
           </div>
         </span>
       </div>

--- a/__tests__/ReactMapboxAutocomplete.spec.js
+++ b/__tests__/ReactMapboxAutocomplete.spec.js
@@ -19,6 +19,26 @@ beforeEach(() => {
   };
 });
 
+describe('render', () => {
+  it('should render component with query results', () => {
+    const wrapper = mount(<ReactMapboxAutocomplete {...state} />);
+    wrapper.setState({ 
+      query: event.target.value,
+      queryResults: mapboxResponse.features
+    });
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('should render component in an error state', () => {
+    const wrapper = mount(<ReactMapboxAutocomplete {...state} />);
+    wrapper.setState({ 
+      error: true,
+      errorMsg: 'There was a problem retrieving data from mapbox'
+    });
+    expect(wrapper).toMatchSnapshot();
+  });
+});
+
 describe('_updateQuery', () => {
   it('should have no query results', () => {
     const wrapper = shallow(<ReactMapboxAutocomplete {...state} />);
@@ -41,7 +61,7 @@ describe('_updateQuery', () => {
     // override fetch mock with failure
     window.fetch = jest.fn().mockImplementation(() => Promise.resolve(mockResponse(400, 'Test Error', '{"status": 400, "statusText": Test Error}')));
 
-    const wrapper = shallow(<ReactMapboxAutocomplete {...state} />);
+    const wrapper = mount(<ReactMapboxAutocomplete {...state} />);
     wrapper.instance()._updateQuery(event)
       .then(() => {
         expect(wrapper.state('error')).toBeTruthy();

--- a/__tests__/ReactMapboxAutocomplete.spec.js
+++ b/__tests__/ReactMapboxAutocomplete.spec.js
@@ -1,0 +1,78 @@
+'use strict';
+
+import 'whatwg-fetch';
+import React from 'react';
+import { shallow, mount } from 'enzyme';
+import mockResponse from '../mocks/mock-response';
+import mapboxResponse from '../mocks/mapbox-response';
+import ReactMapboxAutocomplete from '../ReactMapboxAutocomplete';
+
+let state;
+let event = { target: { value: 'Waitsfield' } };
+window.fetch = jest.fn().mockImplementation(() => Promise.resolve(mockResponse(200, null, JSON.stringify(mapboxResponse))));
+
+beforeEach(() => {
+  state = {
+    publicKey: '',
+    onSuggestionSelect: jest.fn(),
+    query: ''
+  };
+});
+
+describe('_updateQuery', () => {
+  it('should have no query results', () => {
+    const wrapper = shallow(<ReactMapboxAutocomplete {...state} />);
+    expect(wrapper.state('queryResults')).toEqual([]);
+    expect(wrapper.find('.react-mapbox-ac-suggestion')).toHaveLength(0);
+  });
+
+  it('should save the query to state and have query results', () => {
+    const wrapper = shallow(<ReactMapboxAutocomplete {...state} />);
+    wrapper.instance()._updateQuery(event)
+      .then(() => {
+        expect(wrapper.state('query')).toEqual('Waitsfield');
+        expect(wrapper.state('queryResults')).toEqual(mapboxResponse.features)
+        expect(wrapper.find('.react-mapbox-ac-suggestion')).toHaveLength(1);
+      });
+  });
+});
+
+describe('_resetSearch', () => {
+  it('should reset the queryResults', () => {
+    const wrapper = shallow(<ReactMapboxAutocomplete {...state} />);
+    wrapper.instance()._updateQuery(event)
+      .then(() => {
+        wrapper.find('.react-mapbox-ac-menu').simulate('click');
+        expect(wrapper.state('query')).toEqual('Waitsfield');
+        expect(wrapper.state('queryResults')).toEqual([]);
+      });
+  });
+
+  it('should reset the query and queryResults', () => {
+    state.resetSearch = true;
+    const wrapper = shallow(<ReactMapboxAutocomplete {...state} />);
+    wrapper.instance()._updateQuery(event)
+      .then(() => {
+        wrapper.find('.react-mapbox-ac-menu').simulate('click');
+        expect(wrapper.state('query')).toEqual('');
+        expect(wrapper.state('queryResults')).toEqual([]);
+      });
+  });
+});
+
+describe('_onSuggestionSelect', () => {
+  it('should set query to dataset suggestion and invoke callback', () => {
+    const wrapper = mount(<ReactMapboxAutocomplete {...state} />);
+    wrapper.instance()._updateQuery(event)
+      .then(() => {
+        wrapper.find('.react-mapbox-ac-suggestion').first().simulate('click');
+        expect(wrapper.state('query')).toEqual(mapboxResponse.features[0].place_name);
+        expect(wrapper.prop('onSuggestionSelect')).toHaveBeenCalledWith(
+          mapboxResponse.features[0].place_name, 
+          mapboxResponse.features[0].center[1].toString(), 
+          mapboxResponse.features[0].center[0].toString(), 
+          mapboxResponse.features[0].text
+        );
+      });
+  });
+});

--- a/__tests__/__snapshots__/ReactMapboxAutocomplete.spec.js.snap
+++ b/__tests__/__snapshots__/ReactMapboxAutocomplete.spec.js.snap
@@ -1,0 +1,66 @@
+exports[`render should render component in an error state 1`] = `
+<ReactMapboxAutocomplete
+  onSuggestionSelect={[Function]}
+  publicKey=""
+  query="">
+  <div>
+    <input
+      className="react-mapbox-ac-input"
+      onChange={[Function]}
+      placeholder="Search"
+      type="text"
+      value="" />
+    <span>
+      <div
+        className="react-mapbox-ac-menu"
+        onClick={[Function]}
+        style={
+          Object {
+            "display": "block",
+          }
+        }>
+        <div
+          className="react-mapbox-ac-suggestion">
+          There was a problem retrieving data from mapbox
+        </div>
+      </div>
+    </span>
+  </div>
+</ReactMapboxAutocomplete>
+`;
+
+exports[`render should render component with query results 1`] = `
+<ReactMapboxAutocomplete
+  onSuggestionSelect={[Function]}
+  publicKey=""
+  query="">
+  <div>
+    <input
+      className="react-mapbox-ac-input"
+      onChange={[Function]}
+      placeholder="Search"
+      type="text"
+      value="Waitsfield" />
+    <span>
+      <div
+        className="react-mapbox-ac-menu"
+        onClick={[Function]}
+        style={
+          Object {
+            "display": "block",
+          }
+        }>
+        <div
+          className="react-mapbox-ac-suggestion"
+          data-lat={44.1900592468074}
+          data-lng={-72.8245601523668}
+          data-suggestion="Waitsfield Village Historic District, Waitsfield Common, Vermont 05673, United States"
+          data-text="Waitsfield Village Historic District"
+          onClick={[Function]}>
+          Waitsfield Village Historic District, Waitsfield Common, Vermont 05673, United States
+        </div>
+      </div>
+    </span>
+  </div>
+</ReactMapboxAutocomplete>
+`;

--- a/config/CSSStub.js
+++ b/config/CSSStub.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = {};

--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ var ReactMapboxAutocomplete = _react2.default.createClass({
   _updateQuery: function _updateQuery(event) {
     var _this = this;
 
-    this.setState(_.extend(this.state, { query: event.target.value }));
+    this.setState((0, _lodash.extend)(this.state, { query: event.target.value }));
 
     var header = {
       'Content-Type': 'application/json'
@@ -58,12 +58,12 @@ var ReactMapboxAutocomplete = _react2.default.createClass({
       }).then(function (res) {
         return res.json();
       }).then(function (json) {
-        _this.setState(_.extend(_this.state, {
+        _this.setState((0, _lodash.extend)(_this.state, {
           queryResults: json.features
         }));
       });
     } else {
-      this.setState(_.extend(this.state, {
+      this.setState((0, _lodash.extend)(this.state, {
         queryResults: []
       }));
     }
@@ -75,19 +75,19 @@ var ReactMapboxAutocomplete = _react2.default.createClass({
         queryResults: []
       });
     } else {
-      this.setState(_.extend(this.state, {
+      this.setState((0, _lodash.extend)(this.state, {
         queryResults: []
       }));
     }
   },
   _onSuggestionSelect: function _onSuggestionSelect(event) {
     if (this.state.resetSearch === false) {
-      this.setState(_.extend(this.state, {
-        query: event.target.dataset.suggestion
+      this.setState((0, _lodash.extend)(this.state, {
+        query: event.target.getAttribute('data-suggestion')
       }));
     }
 
-    this.props.onSuggestionSelect(event.target.dataset.suggestion, event.target.dataset.lat, event.target.dataset.lng, event.target.dataset.text);
+    this.props.onSuggestionSelect(event.target.getAttribute('data-suggestion'), event.target.getAttribute('data-lat'), event.target.getAttribute('data-lng'), event.target.getAttribute('data-text'));
   },
   render: function render() {
     var _this2 = this;
@@ -108,7 +108,7 @@ var ReactMapboxAutocomplete = _react2.default.createClass({
           { className: 'react-mapbox-ac-menu',
             style: this.state.queryResults.length > 0 ? { display: 'block' } : { display: 'none' },
             onClick: this._resetSearch },
-          _.map(this.state.queryResults, function (place, i) {
+          (0, _lodash.map)(this.state.queryResults, function (place, i) {
             return _react2.default.createElement(
               'div',
               { className: 'react-mapbox-ac-suggestion',

--- a/index.js
+++ b/index.js
@@ -29,6 +29,8 @@ var ReactMapboxAutocomplete = _react2.default.createClass({
 
   getInitialState: function getInitialState() {
     var state = {
+      error: false,
+      errorMsg: '',
       query: this.props.query ? this.props.query : '',
       queryResults: [],
       publicKey: this.props.publicKey,
@@ -56,14 +58,23 @@ var ReactMapboxAutocomplete = _react2.default.createClass({
       return fetch(path, {
         headers: header
       }).then(function (res) {
+        if (!res.ok) throw Error(res.statusText);
         return res.json();
       }).then(function (json) {
         _this.setState((0, _lodash.extend)(_this.state, {
+          error: false,
           queryResults: json.features
+        }));
+      }).catch(function (err) {
+        _this.setState((0, _lodash.extend)(_this.state, {
+          error: true,
+          errorMsg: 'There was a problem retrieving data from mapbox',
+          queryResults: []
         }));
       });
     } else {
       this.setState((0, _lodash.extend)(this.state, {
+        error: false,
         queryResults: []
       }));
     }
@@ -106,7 +117,7 @@ var ReactMapboxAutocomplete = _react2.default.createClass({
         _react2.default.createElement(
           'div',
           { className: 'react-mapbox-ac-menu',
-            style: this.state.queryResults.length > 0 ? { display: 'block' } : { display: 'none' },
+            style: this.state.queryResults.length > 0 || this.state.error ? { display: 'block' } : { display: 'none' },
             onClick: this._resetSearch },
           (0, _lodash.map)(this.state.queryResults, function (place, i) {
             return _react2.default.createElement(
@@ -120,7 +131,12 @@ var ReactMapboxAutocomplete = _react2.default.createClass({
                 'data-text': place.text },
               place.place_name
             );
-          })
+          }),
+          this.state.error && _react2.default.createElement(
+            'div',
+            { className: 'react-mapbox-ac-suggestion' },
+            this.state.errorMsg
+          )
         )
       )
     );

--- a/mocks/mapbox-response.js
+++ b/mocks/mapbox-response.js
@@ -1,0 +1,60 @@
+'use strict';
+
+export default {
+  "type": "FeatureCollection",
+  "query": [
+    "waitsfield"
+  ],
+  "features": [
+    {
+      "id": "poi.4733736148536740",
+      "type": "Feature",
+      "text": "Waitsfield Village Historic District",
+      "place_name": "Waitsfield Village Historic District, Waitsfield Common, Vermont 05673, United States",
+      "relevance": 0.99,
+      "properties": {
+        "wikidata": null,
+        "landmark": true,
+        "tel": null,
+        "address": null,
+        "category": "park",
+        "maki": "picnic-site"
+      },
+      "center": [
+        -72.8245601523668,
+        44.1900592468074
+      ],
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -72.8245601523668,
+          44.1900592468074
+        ]
+      },
+      "context": [
+        {
+          "text": "Waitsfield Common",
+          "id": "place.5535499356755471",
+          "wikidata": null
+        },
+        {
+          "text": "05673",
+          "id": "postcode.12550906067279790"
+        },
+        {
+          "text": "Vermont",
+          "id": "region.10294489344042160",
+          "short_code": "US-VT",
+          "wikidata": "Q16551"
+        },
+        {
+          "text": "United States",
+          "id": "country.3145",
+          "short_code": "us",
+          "wikidata": "Q30"
+        }
+      ]
+    }
+  ],
+  "attribution": "NOTICE: © 2017 Mapbox and its suppliers. All rights reserved. Use of this data is subject to the Mapbox Terms of Service (https://www.mapbox.com/about/maps/). This response and the information it contains may not be retained."
+};

--- a/mocks/mock-response.js
+++ b/mocks/mock-response.js
@@ -1,0 +1,11 @@
+'use strict';
+
+export default function (status, statusText, response) {
+  return new window.Response(response, {
+    status: status,
+    statusText: statusText,
+    headers: {
+      'Content-type': 'application/json'
+    }
+  });
+};

--- a/package.json
+++ b/package.json
@@ -4,7 +4,10 @@
     "verbose": true,
     "moduleNameMapper": {
       "^.+\\.(css|less)$": "<rootDir>/config/CSSStub.js"
-    }
+    },
+    "snapshotSerializers": [
+      "<rootDir>/node_modules/enzyme-to-json/serializer"
+    ]
   },
   "version": "0.2.2",
   "description": "independent react component for mapbox autocomplete",
@@ -40,10 +43,12 @@
   },
   "devDependencies": {
     "babel-cli": "^6.18.0",
+    "babel-jest": "^18.0.0",
     "babel-preset-es2015": "^6.18.0",
     "babel-preset-react": "^6.16.0",
     "babel-preset-stage-0": "^6.16.0",
     "enzyme": "^2.7.0",
+    "enzyme-to-json": "^1.4.5",
     "jest": "^18.1.0",
     "react-addons-test-utils": "^15.4.2"
   }

--- a/package.json
+++ b/package.json
@@ -1,11 +1,18 @@
 {
   "name": "react-mapbox-autocomplete",
+  "jest": {
+    "verbose": true,
+    "moduleNameMapper": {
+      "^.+\\.(css|less)$": "<rootDir>/config/CSSStub.js"
+    }
+  },
   "version": "0.2.2",
   "description": "independent react component for mapbox autocomplete",
   "main": "index.js",
   "scripts": {
     "build": "./node_modules/.bin/babel ReactMapboxAutocomplete.js -o index.js",
-    "prepublish": "npm run build"
+    "prepublish": "npm run build",
+    "test": "jest"
   },
   "repository": {
     "type": "git",
@@ -28,12 +35,16 @@
     "lodash": "^4",
     "lodash-es": "^4",
     "react": "^15",
-    "react-dom": "^15"
+    "react-dom": "^15",
+    "whatwg-fetch": "^2.0.1"
   },
   "devDependencies": {
     "babel-cli": "^6.18.0",
     "babel-preset-es2015": "^6.18.0",
     "babel-preset-react": "^6.16.0",
-    "babel-preset-stage-0": "^6.16.0"
+    "babel-preset-stage-0": "^6.16.0",
+    "enzyme": "^2.7.0",
+    "jest": "^18.1.0",
+    "react-addons-test-utils": "^15.4.2"
   }
 }


### PR DESCRIPTION
This PR adds Jest and Enzyme in order to fully test the component functionality.  I had to make some small changes to the project setup as well as the component to get everything to play nice.

- Jest cannot by default handle CSS module imports.  As such I created a config directory in which there is a stub named "CSSStub.js".  This is passed to Jest to stub CSS imports.
- Fetch needs to be mocked in the tests (since we're not testing whether Fetch works).  I added a mocks directory in which there is a mock json mapbox response and a mock Fetch Response object.  These are used in the tests to mock the Fetch interactions.
- jsdom doesn't support dataset as noted here: https://github.com/tmpvar/jsdom/issues/961  the current recommendation is to use `currentTarget.getAttribute` and I had to make this change in order to properly test `_onSuggestionSelect`.
- Removed _. from Lodash methods in component.  This was breaking the tests and there's no need for the global _ reference when importing the individual methods.

To do:
- [x] add some negative tests
- [x] add render test
- [x] review final build in working app


